### PR TITLE
Replaced hardcoded component keys with a dynamic mapped type based on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this project will be documented in this file. See [Conven
 
 # [2.2.0](https://github.com/schedule-x/svelte/compare/v2.1.0...v2.2.0) (2024-12-25)
 
-
 ### Features
 
-* support svelte 5 ([#43](https://github.com/schedule-x/svelte/issues/43)) ([b6923fa](https://github.com/schedule-x/svelte/commit/b6923fa396233bbe5b7196bd1ddfccf7b2d6c4d7))
+- support svelte 5 ([#43](https://github.com/schedule-x/svelte/issues/43)) ([b6923fa](https://github.com/schedule-x/svelte/commit/b6923fa396233bbe5b7196bd1ddfccf7b2d6c4d7))
 
 # [2.1.0](https://github.com/schedule-x/svelte/compare/v2.0.1...v2.1.0) (2024-11-25)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
 			"version": "2.2.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@schedule-x/theme-default": "^2.0.0",
+				"@schedule-x/theme-default": "^2.18.0",
 				"@semantic-release/changelog": "^6.0.3",
 				"@semantic-release/git": "^10.0.1",
-				"@sveltejs/adapter-auto": "^3.0.0",
+				"@sveltejs/adapter-auto": "^3.3.1",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/package": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -35,7 +35,8 @@
 				"vitest": "^3.0.0"
 			},
 			"peerDependencies": {
-				"@schedule-x/calendar": "^2.0.0",
+				"@schedule-x/calendar": "^2.23.0",
+				"@schedule-x/shared": "^2.23.0",
 				"svelte": "^4 || ^5"
 			}
 		},
@@ -1268,9 +1269,9 @@
 			]
 		},
 		"node_modules/@schedule-x/calendar": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@schedule-x/calendar/-/calendar-2.0.0.tgz",
-			"integrity": "sha512-n2DBAt+thtpUIKcCU6kP4Vt5GTbmnWwXl4VU+c7TwRrmnScCR0b5jen9ejYdZOgQol0KPSK1DC2mrSxYRaC2Bg==",
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/@schedule-x/calendar/-/calendar-2.23.0.tgz",
+			"integrity": "sha512-3APEax4O/U8TIkjVHHaF8cPVblZ4BJW1KMYLffGRFFREkMsur89mHJqKcYryVVTy2+yTi5mP+IZ5vIlYWI9JSg==",
 			"license": "MIT",
 			"peer": true,
 			"peerDependencies": {
@@ -1278,10 +1279,20 @@
 				"preact": "^10.19.2"
 			}
 		},
+		"node_modules/@schedule-x/shared": {
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/@schedule-x/shared/-/shared-2.23.0.tgz",
+			"integrity": "sha512-xMDd0tYLYGgCLwVOZT/VCdg5M8VfCpEXqelIV0b4HdjekpBGiD6mINkNHDCa36h8TZ8LBvVFxDk0jcnNvGWVig==",
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"@preact/signals": "^1.1.5"
+			}
+		},
 		"node_modules/@schedule-x/theme-default": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/@schedule-x/theme-default/-/theme-default-2.13.0.tgz",
-			"integrity": "sha512-pVkDT7h9hkOb0nw4/KQ/WmCRX9DPeVaiJAbIWfcQwi4/iTo1CRiJbO5lXMtg+st4wjFLTn8gHcIPdoI7IpschQ==",
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/@schedule-x/theme-default/-/theme-default-2.23.0.tgz",
+			"integrity": "sha512-FYZ6H9BXGBSNc6e87SdrPR5+G3d2rPcBd4bbxbyICLF+RfZrzKBJQcRTTCYEnX994wvKl7YiawIqIvl8UO01UA==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@sveltejs/adapter-auto": "^3.3.1",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/package": "^2.0.0",
-				"@sveltejs/vite-plugin-svelte": "^3.0.0",
+				"@sveltejs/vite-plugin-svelte": "^4.0.0",
 				"@types/eslint": "^9.0.0",
 				"eslint": "^9.0.0",
 				"eslint-config-prettier": "^9.1.0",
@@ -1927,55 +1927,43 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
-			"integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.4.tgz",
+			"integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
-				"debug": "^4.3.4",
+				"@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
+				"debug": "^4.3.7",
 				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.30.10",
-				"svelte-hmr": "^0.16.0",
-				"vitefu": "^0.2.5"
+				"magic-string": "^0.30.12",
+				"vitefu": "^1.0.3"
 			},
 			"engines": {
-				"node": "^18.0.0 || >=20"
+				"node": "^18.0.0 || ^20.0.0 || >=22"
 			},
 			"peerDependencies": {
-				"svelte": "^4.0.0 || ^5.0.0-next.0",
+				"svelte": "^5.0.0-next.96 || ^5.0.0",
 				"vite": "^5.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.1.0.tgz",
-			"integrity": "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-3.0.1.tgz",
+			"integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.3.4"
+				"debug": "^4.3.7"
 			},
 			"engines": {
-				"node": "^18.0.0 || >=20"
+				"node": "^18.0.0 || ^20.0.0 || >=22"
 			},
 			"peerDependencies": {
-				"@sveltejs/vite-plugin-svelte": "^3.0.0",
-				"svelte": "^4.0.0 || ^5.0.0-next.0",
+				"@sveltejs/vite-plugin-svelte": "^4.0.0-next.0||^4.0.0",
+				"svelte": "^5.0.0-next.96 || ^5.0.0",
 				"vite": "^5.0.0"
-			}
-		},
-		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/svelte-hmr": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
-			"integrity": "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20 || ^14.13.1 || >= 16"
-			},
-			"peerDependencies": {
-				"svelte": "^3.19.0 || ^4.0.0"
 			}
 		},
 		"node_modules/@types/cookie": {
@@ -9372,12 +9360,17 @@
 			}
 		},
 		"node_modules/vitefu": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
-			"integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.6.tgz",
+			"integrity": "sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==",
 			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"tests/deps/*",
+				"tests/projects/*"
+			],
 			"peerDependencies": {
-				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
 			},
 			"peerDependenciesMeta": {
 				"vite": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@sveltejs/adapter-auto": "^3.3.1",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/package": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"@sveltejs/vite-plugin-svelte": "^4.0.0",
 		"@types/eslint": "^9.0.0",
 		"eslint": "^9.0.0",
 		"eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,15 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"@schedule-x/calendar": "^2.0.0",
+		"@schedule-x/calendar": "^2.23.0",
+		"@schedule-x/shared": "^2.23.0",
 		"svelte": "^4 || ^5"
 	},
 	"devDependencies": {
-		"@schedule-x/theme-default": "^2.0.0",
+		"@schedule-x/theme-default": "^2.18.0",
 		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
-		"@sveltejs/adapter-auto": "^3.0.0",
+		"@sveltejs/adapter-auto": "^3.3.1",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/package": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/src/lib/components/schedule-x-calendar.svelte
+++ b/src/lib/components/schedule-x-calendar.svelte
@@ -4,78 +4,44 @@
 	import { createCustomComponentFn } from '$lib/utils/create-custom-component-fn.js';
 	import Portal from '$lib/utils/Portal.svelte';
 
-	import type { CustomComponentMeta, CustomComponents } from '$lib/types/custom-components.js';
+	import type { CustomComponentMeta } from '$lib/types/custom-components.js';
 	import type { CalendarApp } from '@schedule-x/calendar';
 
 	export let calendarApp: CalendarApp;
 
-	export let timeGridEvent: CustomComponents['timeGridEvent'] | undefined = undefined;
-	export let dateGridEvent: CustomComponents['dateGridEvent'] | undefined = undefined;
-	export let monthGridEvent: CustomComponents['monthGridEvent'] | undefined = undefined;
-	export let monthAgendaEvent: CustomComponents['monthAgendaEvent'] | undefined = undefined;
-	export let eventModal: CustomComponents['eventModal'] | undefined = undefined;
-	export let headerContentLeftPrepend: CustomComponents['headerContentLeftPrepend'] | undefined =
-		undefined;
-	export let headerContentLeftAppend: CustomComponents['headerContentLeftAppend'] | undefined =
-		undefined;
-	export let headerContentRightPrepend: CustomComponents['headerContentRightPrepend'] | undefined =
-		undefined;
-	export let headerContentRightAppend: CustomComponents['headerContentRightAppend'] | undefined =
-		undefined;
-	export let headerContent: CustomComponents['headerContent'] | undefined = undefined;
-
 	let customComponentsMeta: CustomComponentMeta[] = [];
-
 	$: wrapperId = randomStringId();
-	$: customComponentsMeta = [];
 
 	const setComponent = (component: CustomComponentMeta) => {
 		const newComponents = [...customComponentsMeta];
 		const ccid = component.wrapperElement.dataset.ccid;
-		const existingComponent = newComponents.find((c) => c.wrapperElement.dataset.ccid === ccid);
+		const existing = newComponents.find((c) => c.wrapperElement.dataset.ccid === ccid);
 
-		if (existingComponent) {
-			newComponents.splice(newComponents.indexOf(existingComponent), 1);
+		if (existing) {
+			newComponents.splice(newComponents.indexOf(existing), 1);
 		}
 
 		customComponentsMeta = [...newComponents, component];
 	};
 
 	const setCustomComponentFns = () => {
-		const customComponentsAvailable: {
-			name: keyof CustomComponents;
-			component: CustomComponents[keyof CustomComponents];
-		}[] = [
-			{ name: 'timeGridEvent', component: timeGridEvent },
-			{ name: 'dateGridEvent', component: dateGridEvent },
-			{ name: 'monthGridEvent', component: monthGridEvent },
-			{ name: 'monthAgendaEvent', component: monthAgendaEvent },
-			{ name: 'eventModal', component: eventModal },
-			{ name: 'headerContentLeftPrepend', component: headerContentLeftPrepend },
-			{ name: 'headerContentLeftAppend', component: headerContentLeftAppend },
-			{ name: 'headerContentRightPrepend', component: headerContentRightPrepend },
-			{ name: 'headerContentRightAppend', component: headerContentRightAppend },
-			{ name: 'headerContent', component: headerContent }
-		];
-
-		customComponentsAvailable.forEach(({ name, component }) => {
+		Object.entries($$restProps).forEach(([name, component]) => {
 			if (component) {
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
 				calendarApp._setCustomComponentFn(name, createCustomComponentFn(setComponent, component));
 			}
 		});
 	};
 
-	onMount(() => {
+	$: if (calendarApp) {
 		setCustomComponentFns();
+	}
 
+	onMount(() => {
 		const wrapper = document.getElementById(wrapperId);
 		if (!(wrapper instanceof HTMLElement)) {
 			console.warn('Could not find wrapper element to mount calendar on');
 			return;
 		}
-
 		calendarApp.render(wrapper);
 	});
 </script>

--- a/src/lib/components/schedule-x-calendar.svelte
+++ b/src/lib/components/schedule-x-calendar.svelte
@@ -32,16 +32,15 @@
 		});
 	};
 
-	$: if (calendarApp) {
-		setCustomComponentFns();
-	}
-
 	onMount(() => {
 		const wrapper = document.getElementById(wrapperId);
 		if (!(wrapper instanceof HTMLElement)) {
 			console.warn('Could not find wrapper element to mount calendar on');
 			return;
 		}
+
+		setCustomComponentFns();
+
 		calendarApp.render(wrapper);
 	});
 </script>

--- a/src/lib/types/custom-components.ts
+++ b/src/lib/types/custom-components.ts
@@ -1,30 +1,18 @@
 import type { SvelteComponent } from 'svelte';
-import type { CalendarEvent } from '@schedule-x/calendar';
+import type { CustomComponentName } from '@schedule-x/shared';
 
-type TimeGridEvent = typeof SvelteComponent<{ calendarEvent: CalendarEvent }>;
-type DateGridEvent = typeof SvelteComponent<{ calendarEvent: CalendarEvent }>;
-type MonthGridEvent = typeof SvelteComponent<{
-	calendarEvent: CalendarEvent;
-	hasStartDate: boolean;
-}>;
-type MonthAgendaEvent = typeof SvelteComponent<{ calendarEvent: CalendarEvent }>;
-type EventModal = typeof SvelteComponent<{ calendarEvent: CalendarEvent }>;
+type ComponentType<Props extends Record<string, unknown> = Record<string, unknown>> = new (
+	...args: unknown[]
+) => SvelteComponent<Props>;
 
 export type CustomComponents = {
-	timeGridEvent?: TimeGridEvent;
-	dateGridEvent?: DateGridEvent;
-	monthGridEvent?: MonthGridEvent;
-	monthAgendaEvent?: MonthAgendaEvent;
-	eventModal?: EventModal;
-	headerContentLeftPrepend?: typeof SvelteComponent<{ [x: string]: never }>;
-	headerContentLeftAppend?: typeof SvelteComponent<{ [x: string]: never }>;
-	headerContentRightPrepend?: typeof SvelteComponent<{ [x: string]: never }>;
-	headerContentRightAppend?: typeof SvelteComponent<{ [x: string]: never }>;
-	headerContent?: typeof SvelteComponent<{ [x: string]: never }>;
+	[key in CustomComponentName]?: ComponentType;
 };
+
 export type CustomComponentMeta = {
-	Component: SvelteComponent;
+	Component: ComponentType;
 	wrapperElement: HTMLElement;
 	props: Record<string, unknown>;
 };
+
 export type CustomComponentsMeta = CustomComponentMeta[];

--- a/src/lib/utils/Portal.svelte
+++ b/src/lib/utils/Portal.svelte
@@ -1,24 +1,28 @@
-<script context="module">
+<script context="module" lang="ts">
 	import { tick } from 'svelte';
 
 	/**
 	 * Usage: <div use:portal={'css selector'}> or <div use:portal={document.body}>
 	 *
-	 * @param {HTMLElement} el
-	 * @param {HTMLElement|string} target DOM Element or CSS Selector
+	 * @param el - The element to move
+	 * @param target - DOM element or CSS selector
 	 */
-	export function portal(el, target = 'body') {
-		let targetEl;
-		async function update(newTarget) {
+	export function portal(el: HTMLElement, target: HTMLElement | string = 'body') {
+		let targetEl: HTMLElement;
+
+		async function update(newTarget: string | HTMLElement) {
 			target = newTarget;
+
 			if (typeof target === 'string') {
-				targetEl = document.querySelector(target);
+				targetEl = document.querySelector(target)!;
+
 				if (targetEl === null) {
 					await tick();
-					targetEl = document.querySelector(target);
+					targetEl = document.querySelector(target)!;
 				}
+
 				if (targetEl === null) {
-					throw new Error(`No element found matching css selector: "${target}"`);
+					throw new Error(`No element found matching CSS selector: "${target}"`);
 				}
 			} else if (target instanceof HTMLElement) {
 				targetEl = target;
@@ -29,6 +33,7 @@
 					}. Allowed types: string (CSS selector) or HTMLElement.`
 				);
 			}
+
 			targetEl.appendChild(el);
 			el.hidden = false;
 		}
@@ -40,6 +45,7 @@
 		}
 
 		update(target);
+
 		return {
 			update,
 			destroy
@@ -47,12 +53,9 @@
 	}
 </script>
 
-<script>
-	/**
-	 * DOM Element or CSS Selector
-	 * @type { HTMLElement|string}
-	 */
-	export let target = 'body';
+<script lang="ts">
+	// Accepts a DOM element or CSS selector
+	export let target: HTMLElement | string = 'body';
 </script>
 
 <div style="height: 100%; width: 100%" use:portal={target} hidden>

--- a/src/lib/utils/create-custom-component-fn.ts
+++ b/src/lib/utils/create-custom-component-fn.ts
@@ -4,7 +4,7 @@ import type { SvelteComponent } from 'svelte';
 export const createCustomComponentFn =
 	(
 		setCustomComponent: (component: CustomComponentMeta) => void,
-		customComponent: SvelteComponent
+		customComponent: typeof SvelteComponent
 	) =>
 	(wrapperElement: HTMLElement, props: Record<string, unknown>) => {
 		setCustomComponent({

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,8 @@
 	import ScheduleXCalendar from '../lib/components/schedule-x-calendar.svelte';
 	import TimeGridEvent from './components/time-grid-event.svelte';
 	import HeaderContent from './components/header-content.svelte';
+	import WeekGridDate from './components/week-grid-date.svelte';
+
 	import { createCalendar, viewDay, viewWeek } from '@schedule-x/calendar';
 
 	const calendarApp = createCalendar({
@@ -39,5 +41,10 @@
 </script>
 
 <div>
-	<ScheduleXCalendar {calendarApp} timeGridEvent={TimeGridEvent} headerContent={HeaderContent} />
+	<ScheduleXCalendar
+		{calendarApp}
+		timeGridEvent={TimeGridEvent}
+		headerContent={HeaderContent}
+		weekGridDate={WeekGridDate}
+	/>
 </div>

--- a/src/routes/components/week-grid-date.svelte
+++ b/src/routes/components/week-grid-date.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	export let date: Date;
+
+	const formatter = new Intl.DateTimeFormat('en-US', { weekday: 'short' });
+	const day = formatter.format(new Date(date)).toUpperCase();
+</script>
+
+<span class="custom-week-grid-date">
+	{day}
+</span>


### PR DESCRIPTION
**### Svelte Custom Components for Schedule-X**
Allow users to pass custom Svelte components (like timeGridEvent, headerContent, etc.) to Schedule-X in the same way as the Vue/React integration. Since CustomComponentName is in @schedule-x/shared there is no need for adding them manually.

**Wrap up**
- Uses $$restProps to capture all custom component props dynamically
- Registers them via calendarApp._setCustomComponentFn(...)
- No need to manually declare each prop like export let timeGridEvent



